### PR TITLE
Add compatibility for Symfony versions 3.1 and up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,14 @@ matrix:
   include:
     - php: 5.6
     - php: 7.0
-    - php: 7.0
+    - php: 7.1
       env: SYMFONY_VERSION=2.8.*
+    - php: 7.1
+      env: SYMFONY_VERSION=3.0.*
+    - php: 7.1
+      env: SYMFONY_VERSION=3.1.*
+    - php: 7.1
+      env: SYMFONY_VERSION=3.2.*
     - php: 7.1
 
 before_install: composer selfupdate

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,11 @@
     },
     "require": {
         "php": "^5.6 || ^7.0",
-        "doctrine/doctrine-bundle": "~1.6.0",
-        "symfony/ldap": "^2.8 || ~3.0.0",
+        "doctrine/doctrine-bundle": "^1.6",
+        "symfony/ldap": "^2.8 || ^3.0",
         "symfony/property-access": "^2.8 || ^3.0",
-        "symfony/security": "^2.8 || ~3.0.0",
-        "symfony/security-bundle": "^2.8 || ~3.0.0"
+        "symfony/security": "^2.8 || ^3.0",
+        "symfony/security-bundle": "^2.8 || ^3.0"
     },
     "require-dev": {
         "jackalope/jackalope": "^1.3",
@@ -33,10 +33,12 @@
         "matthiasnoback/symfony-dependency-injection-test": "^1.1",
         "phpunit/phpunit": "^5.7",
         "satooshi/php-coveralls": "^1.0",
-        "sulu/sulu": "^1.4",
-        "symfony/symfony": "^2.8 || ~3.0.0"
+        "sulu/sulu": "^1.4"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "platform": {
+            "php": "5.6.32"
+        }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "7f8034bd381290b3f0d267cd2cc05bf1",
+    "content-hash": "cf0be856bdb5b8e6486f3fc9ff194770",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -357,16 +357,16 @@
         },
         {
             "name": "doctrine/doctrine-bundle",
-            "version": "1.6.8",
+            "version": "1.6.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/DoctrineBundle.git",
-                "reference": "6e96577cbbdbb5b6dcca2ff203d665976b51beb0"
+                "reference": "8cd4c2921b6cef14a78d98cd3f0fb81ba6a976f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/DoctrineBundle/zipball/6e96577cbbdbb5b6dcca2ff203d665976b51beb0",
-                "reference": "6e96577cbbdbb5b6dcca2ff203d665976b51beb0",
+                "url": "https://api.github.com/repos/doctrine/DoctrineBundle/zipball/8cd4c2921b6cef14a78d98cd3f0fb81ba6a976f9",
+                "reference": "8cd4c2921b6cef14a78d98cd3f0fb81ba6a976f9",
                 "shasum": ""
             },
             "require": {
@@ -434,27 +434,27 @@
                 "orm",
                 "persistence"
             ],
-            "time": "2017-05-18T08:15:18+00:00"
+            "time": "2017-10-11T19:48:03+00:00"
         },
         {
             "name": "doctrine/doctrine-cache-bundle",
-            "version": "1.3.0",
+            "version": "1.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/DoctrineCacheBundle.git",
-                "reference": "18c600a9b82f6454d2e81ca4957cdd56a1cf3504"
+                "reference": "9baecbd6bfdd1123b0cf8c1b88fee0170a84ddd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/DoctrineCacheBundle/zipball/18c600a9b82f6454d2e81ca4957cdd56a1cf3504",
-                "reference": "18c600a9b82f6454d2e81ca4957cdd56a1cf3504",
+                "url": "https://api.github.com/repos/doctrine/DoctrineCacheBundle/zipball/9baecbd6bfdd1123b0cf8c1b88fee0170a84ddd1",
+                "reference": "9baecbd6bfdd1123b0cf8c1b88fee0170a84ddd1",
                 "shasum": ""
             },
             "require": {
                 "doctrine/cache": "^1.4.2",
                 "doctrine/inflector": "~1.0",
                 "php": ">=5.3.2",
-                "symfony/doctrine-bridge": "~2.2|~3.0"
+                "symfony/doctrine-bridge": "~2.2|~3.0|~4.0"
             },
             "require-dev": {
                 "instaclick/coding-standard": "~1.1",
@@ -462,15 +462,15 @@
                 "instaclick/symfony2-coding-standard": "dev-remaster",
                 "phpunit/phpunit": "~4",
                 "predis/predis": "~0.8",
-                "satooshi/php-coveralls": "~0.6.1",
+                "satooshi/php-coveralls": "^1.0",
                 "squizlabs/php_codesniffer": "~1.5",
-                "symfony/console": "~2.2|~3.0",
-                "symfony/finder": "~2.2|~3.0",
-                "symfony/framework-bundle": "~2.2|~3.0",
-                "symfony/phpunit-bridge": "~2.7|~3.0",
+                "symfony/console": "~2.2|~3.0|~4.0",
+                "symfony/finder": "~2.2|~3.0|~4.0",
+                "symfony/framework-bundle": "~2.2|~3.0|~4.0",
+                "symfony/phpunit-bridge": "~2.7|~3.0|~4.0",
                 "symfony/security-acl": "~2.3|~3.0",
-                "symfony/validator": "~2.2|~3.0",
-                "symfony/yaml": "~2.2|~3.0"
+                "symfony/validator": "~2.2|~3.0|~4.0",
+                "symfony/yaml": "~2.2|~3.0|~4.0"
             },
             "suggest": {
                 "symfony/security-acl": "For using this bundle to cache ACLs"
@@ -478,7 +478,7 @@
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "1.3.x-dev"
                 }
             },
             "autoload": {
@@ -522,7 +522,7 @@
                 "cache",
                 "caching"
             ],
-            "time": "2016-01-26T17:28:51+00:00"
+            "time": "2017-10-12T17:23:29+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -646,6 +646,60 @@
             "time": "2014-09-09T13:34:57+00:00"
         },
         {
+            "name": "fig/link-util",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/link-util.git",
+                "reference": "1a07821801a148be4add11ab0603e4af55a72fac"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/link-util/zipball/1a07821801a148be4add11ab0603e4af55a72fac",
+                "reference": "1a07821801a148be4add11ab0603e4af55a72fac",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.0",
+                "psr/link": "~1.0@dev"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.1",
+                "squizlabs/php_codesniffer": "^2.3.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Fig\\Link\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common utility implementations for HTTP links",
+            "keywords": [
+                "http",
+                "http-link",
+                "link",
+                "psr",
+                "psr-13",
+                "rest"
+            ],
+            "time": "2016-10-17T18:31:11+00:00"
+        },
+        {
             "name": "jdorn/sql-formatter",
             "version": "v1.2.17",
             "source": {
@@ -697,16 +751,16 @@
         },
         {
             "name": "paragonie/random_compat",
-            "version": "v2.0.10",
+            "version": "v2.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "634bae8e911eefa89c1abfbf1b66da679ac8f54d"
+                "reference": "5da4d3c796c275c55f057af5a643ae297d96b4d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/634bae8e911eefa89c1abfbf1b66da679ac8f54d",
-                "reference": "634bae8e911eefa89c1abfbf1b66da679ac8f54d",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/5da4d3c796c275c55f057af5a643ae297d96b4d8",
+                "reference": "5da4d3c796c275c55f057af5a643ae297d96b4d8",
                 "shasum": ""
             },
             "require": {
@@ -741,7 +795,151 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2017-03-13T16:27:32+00:00"
+            "time": "2017-09-27T21:40:39+00:00"
+        },
+        {
+            "name": "psr/cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "time": "2016-08-06T20:24:11+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
+            "name": "psr/link",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/link.git",
+                "reference": "eea8e8662d5cd3ae4517c9b864493f59fca95562"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/link/zipball/eea8e8662d5cd3ae4517c9b864493f59fca95562",
+                "reference": "eea8e8662d5cd3ae4517c9b864493f59fca95562",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Link\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for HTTP links",
+            "keywords": [
+                "http",
+                "http-link",
+                "link",
+                "psr",
+                "psr-13",
+                "rest"
+            ],
+            "time": "2016-10-28T16:06:13+00:00"
         },
         {
             "name": "psr/log",
@@ -791,17 +989,121 @@
             "time": "2016-10-10T12:19:37+00:00"
         },
         {
-            "name": "symfony/polyfill-intl-icu",
-            "version": "v1.5.0",
+            "name": "psr/simple-cache",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-intl-icu.git",
-                "reference": "4aa0b65dc71a7369c1e7e6e2a3ca027d9decdb09"
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "753fa598e8f3b9966c886fe13f370baa45ef0e24"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-icu/zipball/4aa0b65dc71a7369c1e7e6e2a3ca027d9decdb09",
-                "reference": "4aa0b65dc71a7369c1e7e6e2a3ca027d9decdb09",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/753fa598e8f3b9966c886fe13f370baa45ef0e24",
+                "reference": "753fa598e8f3b9966c886fe13f370baa45ef0e24",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "time": "2017-01-02T13:31:39+00:00"
+        },
+        {
+            "name": "symfony/polyfill-apcu",
+            "version": "v1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-apcu.git",
+                "reference": "04f62674339602def515bff4bc6901fc1d4951e8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-apcu/zipball/04f62674339602def515bff4bc6901fc1d4951e8",
+                "reference": "04f62674339602def515bff4bc6901fc1d4951e8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Apcu\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting apcu_* functions to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "apcu",
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2017-10-11T12:05:26+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-icu",
+            "version": "v1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-icu.git",
+                "reference": "d2bb2ef00dd8605d6fbd4db53ed4af1395953497"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-icu/zipball/d2bb2ef00dd8605d6fbd4db53ed4af1395953497",
+                "reference": "d2bb2ef00dd8605d6fbd4db53ed4af1395953497",
                 "shasum": ""
             },
             "require": {
@@ -814,7 +1116,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.5-dev"
+                    "dev-master": "1.6-dev"
                 }
             },
             "autoload": {
@@ -846,20 +1148,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2017-06-14T15:44:48+00:00"
+            "time": "2017-10-11T12:05:26+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.5.0",
+            "version": "v1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "7c8fae0ac1d216eb54349e6a8baa57d515fe8803"
+                "reference": "2ec8b39c38cb16674bbf3fea2b6ce5bf117e1296"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/7c8fae0ac1d216eb54349e6a8baa57d515fe8803",
-                "reference": "7c8fae0ac1d216eb54349e6a8baa57d515fe8803",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/2ec8b39c38cb16674bbf3fea2b6ce5bf117e1296",
+                "reference": "2ec8b39c38cb16674bbf3fea2b6ce5bf117e1296",
                 "shasum": ""
             },
             "require": {
@@ -871,7 +1173,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.5-dev"
+                    "dev-master": "1.6-dev"
                 }
             },
             "autoload": {
@@ -905,20 +1207,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2017-06-14T15:44:48+00:00"
+            "time": "2017-10-11T12:05:26+00:00"
         },
         {
             "name": "symfony/polyfill-php56",
-            "version": "v1.5.0",
+            "version": "v1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php56.git",
-                "reference": "e85ebdef569b84e8709864e1a290c40f156b30ca"
+                "reference": "265fc96795492430762c29be291a371494ba3a5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php56/zipball/e85ebdef569b84e8709864e1a290c40f156b30ca",
-                "reference": "e85ebdef569b84e8709864e1a290c40f156b30ca",
+                "url": "https://api.github.com/repos/symfony/polyfill-php56/zipball/265fc96795492430762c29be291a371494ba3a5b",
+                "reference": "265fc96795492430762c29be291a371494ba3a5b",
                 "shasum": ""
             },
             "require": {
@@ -928,7 +1230,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.5-dev"
+                    "dev-master": "1.6-dev"
                 }
             },
             "autoload": {
@@ -961,20 +1263,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2017-06-14T15:44:48+00:00"
+            "time": "2017-10-11T12:05:26+00:00"
         },
         {
             "name": "symfony/polyfill-php70",
-            "version": "v1.5.0",
+            "version": "v1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php70.git",
-                "reference": "b6482e68974486984f59449ecea1fbbb22ff840f"
+                "reference": "0442b9c0596610bd24ae7b5f0a6cdbbc16d9fcff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/b6482e68974486984f59449ecea1fbbb22ff840f",
-                "reference": "b6482e68974486984f59449ecea1fbbb22ff840f",
+                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/0442b9c0596610bd24ae7b5f0a6cdbbc16d9fcff",
+                "reference": "0442b9c0596610bd24ae7b5f0a6cdbbc16d9fcff",
                 "shasum": ""
             },
             "require": {
@@ -984,7 +1286,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.5-dev"
+                    "dev-master": "1.6-dev"
                 }
             },
             "autoload": {
@@ -1020,20 +1322,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2017-06-14T15:44:48+00:00"
+            "time": "2017-10-11T12:05:26+00:00"
         },
         {
             "name": "symfony/polyfill-util",
-            "version": "v1.5.0",
+            "version": "v1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-util.git",
-                "reference": "67925d1cf0b84bd234a83bebf26d4eb281744c6d"
+                "reference": "6e719200c8e540e0c0effeb31f96bdb344b94176"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-util/zipball/67925d1cf0b84bd234a83bebf26d4eb281744c6d",
-                "reference": "67925d1cf0b84bd234a83bebf26d4eb281744c6d",
+                "url": "https://api.github.com/repos/symfony/polyfill-util/zipball/6e719200c8e540e0c0effeb31f96bdb344b94176",
+                "reference": "6e719200c8e540e0c0effeb31f96bdb344b94176",
                 "shasum": ""
             },
             "require": {
@@ -1042,7 +1344,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.5-dev"
+                    "dev-master": "1.6-dev"
                 }
             },
             "autoload": {
@@ -1072,39 +1374,54 @@
                 "polyfill",
                 "shim"
             ],
-            "time": "2017-07-05T15:09:33+00:00"
+            "time": "2017-10-11T12:05:26+00:00"
         },
         {
             "name": "symfony/symfony",
-            "version": "v3.0.9",
+            "version": "v3.3.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/symfony.git",
-                "reference": "634fb8c018532c820debd2678e452a735b9f438e"
+                "reference": "cfef3b2d505ae4375b17032bd03ed9a3da4b7b43"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/symfony/zipball/634fb8c018532c820debd2678e452a735b9f438e",
-                "reference": "634fb8c018532c820debd2678e452a735b9f438e",
+                "url": "https://api.github.com/repos/symfony/symfony/zipball/cfef3b2d505ae4375b17032bd03ed9a3da4b7b43",
+                "reference": "cfef3b2d505ae4375b17032bd03ed9a3da4b7b43",
                 "shasum": ""
             },
             "require": {
                 "doctrine/common": "~2.4",
-                "php": ">=5.5.9",
+                "ext-xml": "*",
+                "fig/link-util": "^1.0",
+                "php": "^5.5.9|>=7.0.8",
+                "psr/cache": "~1.0",
+                "psr/container": "^1.0",
+                "psr/link": "^1.0",
                 "psr/log": "~1.0",
+                "psr/simple-cache": "^1.0",
+                "symfony/polyfill-apcu": "~1.1",
                 "symfony/polyfill-intl-icu": "~1.0",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/polyfill-php56": "~1.0",
                 "symfony/polyfill-php70": "~1.0",
                 "symfony/polyfill-util": "~1.0",
-                "twig/twig": "~1.23|~2.0"
+                "twig/twig": "~1.34|~2.4"
             },
             "conflict": {
-                "phpdocumentor/reflection": "<1.0.7"
+                "phpdocumentor/reflection-docblock": "<3.0||>=3.2.0,<3.2.2",
+                "phpdocumentor/type-resolver": "<0.2.0",
+                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
+            },
+            "provide": {
+                "psr/cache-implementation": "1.0",
+                "psr/container-implementation": "1.0",
+                "psr/simple-cache-implementation": "1.0"
             },
             "replace": {
                 "symfony/asset": "self.version",
                 "symfony/browser-kit": "self.version",
+                "symfony/cache": "self.version",
                 "symfony/class-loader": "self.version",
                 "symfony/config": "self.version",
                 "symfony/console": "self.version",
@@ -1114,6 +1431,7 @@
                 "symfony/dependency-injection": "self.version",
                 "symfony/doctrine-bridge": "self.version",
                 "symfony/dom-crawler": "self.version",
+                "symfony/dotenv": "self.version",
                 "symfony/event-dispatcher": "self.version",
                 "symfony/expression-language": "self.version",
                 "symfony/filesystem": "self.version",
@@ -1122,6 +1440,7 @@
                 "symfony/framework-bundle": "self.version",
                 "symfony/http-foundation": "self.version",
                 "symfony/http-kernel": "self.version",
+                "symfony/inflector": "self.version",
                 "symfony/intl": "self.version",
                 "symfony/ldap": "self.version",
                 "symfony/monolog-bridge": "self.version",
@@ -1145,25 +1464,32 @@
                 "symfony/twig-bundle": "self.version",
                 "symfony/validator": "self.version",
                 "symfony/var-dumper": "self.version",
+                "symfony/web-link": "self.version",
                 "symfony/web-profiler-bundle": "self.version",
+                "symfony/web-server-bundle": "self.version",
+                "symfony/workflow": "self.version",
                 "symfony/yaml": "self.version"
             },
             "require-dev": {
+                "cache/integration-tests": "dev-master",
+                "doctrine/cache": "~1.6",
                 "doctrine/data-fixtures": "1.0.*",
                 "doctrine/dbal": "~2.4",
                 "doctrine/doctrine-bundle": "~1.4",
                 "doctrine/orm": "~2.4,>=2.4.5",
-                "egulias/email-validator": "~1.2,>=1.2.1",
+                "egulias/email-validator": "~1.2,>=1.2.8|~2.0",
                 "monolog/monolog": "~1.11",
                 "ocramius/proxy-manager": "~0.4|~1.0|~2.0",
-                "phpdocumentor/reflection": "^1.0.7",
-                "symfony/polyfill-apcu": "~1.1",
+                "phpdocumentor/reflection-docblock": "^3.0|^4.0",
+                "predis/predis": "~1.0",
+                "sensio/framework-extra-bundle": "^3.0.2",
+                "symfony/phpunit-bridge": "~3.2",
                 "symfony/security-acl": "~2.8|~3.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "3.3-dev"
                 }
             },
             "autoload": {
@@ -1171,7 +1497,6 @@
                     "Symfony\\Bridge\\Doctrine\\": "src/Symfony/Bridge/Doctrine/",
                     "Symfony\\Bridge\\Monolog\\": "src/Symfony/Bridge/Monolog/",
                     "Symfony\\Bridge\\ProxyManager\\": "src/Symfony/Bridge/ProxyManager/",
-                    "Symfony\\Bridge\\Swiftmailer\\": "src/Symfony/Bridge/Swiftmailer/",
                     "Symfony\\Bridge\\Twig\\": "src/Symfony/Bridge/Twig/",
                     "Symfony\\Bundle\\": "src/Symfony/Bundle/",
                     "Symfony\\Component\\": "src/Symfony/Component/"
@@ -1202,20 +1527,20 @@
             "keywords": [
                 "framework"
             ],
-            "time": "2016-07-30T09:10:53+00:00"
+            "time": "2017-10-05T23:40:32+00:00"
         },
         {
             "name": "twig/twig",
-            "version": "v1.34.4",
+            "version": "v1.35.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "f878bab48edb66ad9c6ed626bf817f60c6c096ee"
+                "reference": "daa657073e55b0a78cce8fdd22682fddecc6385f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/f878bab48edb66ad9c6ed626bf817f60c6c096ee",
-                "reference": "f878bab48edb66ad9c6ed626bf817f60c6c096ee",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/daa657073e55b0a78cce8fdd22682fddecc6385f",
+                "reference": "daa657073e55b0a78cce8fdd22682fddecc6385f",
                 "shasum": ""
             },
             "require": {
@@ -1229,7 +1554,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.34-dev"
+                    "dev-master": "1.35-dev"
                 }
             },
             "autoload": {
@@ -1267,7 +1592,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2017-07-04T13:19:31+00:00"
+            "time": "2017-09-27T18:06:46+00:00"
         }
     ],
     "packages-dev": [
@@ -1577,16 +1902,16 @@
         },
         {
             "name": "doctrine/orm",
-            "version": "v2.5.10",
+            "version": "v2.5.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/doctrine2.git",
-                "reference": "c78afd51721804f4f76ff30d9b6f6159eb046161"
+                "reference": "984535cadc609e9eef8c89414aa3568ee97aa79f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/doctrine2/zipball/c78afd51721804f4f76ff30d9b6f6159eb046161",
-                "reference": "c78afd51721804f4f76ff30d9b6f6159eb046161",
+                "url": "https://api.github.com/repos/doctrine/doctrine2/zipball/984535cadc609e9eef8c89414aa3568ee97aa79f",
+                "reference": "984535cadc609e9eef8c89414aa3568ee97aa79f",
                 "shasum": ""
             },
             "require": {
@@ -1594,14 +1919,14 @@
                 "doctrine/collections": "~1.2",
                 "doctrine/common": ">=2.5-dev,<2.9-dev",
                 "doctrine/dbal": ">=2.5-dev,<2.7-dev",
-                "doctrine/instantiator": "~1.0.1",
+                "doctrine/instantiator": "^1.0.1",
                 "ext-pdo": "*",
                 "php": ">=5.4",
-                "symfony/console": "~2.5|~3.0"
+                "symfony/console": "~2.5|~3.0|~4.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "~4.0",
-                "symfony/yaml": "~2.3|~3.0"
+                "symfony/yaml": "~2.3|~3.0|~4.0"
             },
             "suggest": {
                 "symfony/yaml": "If you want to use YAML Metadata Mapping Driver"
@@ -1649,7 +1974,7 @@
                 "database",
                 "orm"
             ],
-            "time": "2017-08-18T19:17:35+00:00"
+            "time": "2017-10-23T18:21:04+00:00"
         },
         {
             "name": "doctrine/phpcr-bundle",
@@ -1778,71 +2103,17 @@
             "time": "2017-07-17T17:39:19+00:00"
         },
         {
-            "name": "fig/link-util",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/link-util.git",
-                "reference": "1a07821801a148be4add11ab0603e4af55a72fac"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/link-util/zipball/1a07821801a148be4add11ab0603e4af55a72fac",
-                "reference": "1a07821801a148be4add11ab0603e4af55a72fac",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5.0",
-                "psr/link": "~1.0@dev"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.1",
-                "squizlabs/php_codesniffer": "^2.3.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Fig\\Link\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common utility implementations for HTTP links",
-            "keywords": [
-                "http",
-                "http-link",
-                "link",
-                "psr",
-                "psr-13",
-                "rest"
-            ],
-            "time": "2016-10-17T18:31:11+00:00"
-        },
-        {
             "name": "friendsofsymfony/http-cache",
-            "version": "1.4.3",
+            "version": "1.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfSymfony/FOSHttpCache.git",
-                "reference": "de883f0a76d78935278942e25e093418bfbe6c26"
+                "reference": "e528b0fb046d3f329b10951201a5b0cab60e96e1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfSymfony/FOSHttpCache/zipball/de883f0a76d78935278942e25e093418bfbe6c26",
-                "reference": "de883f0a76d78935278942e25e093418bfbe6c26",
+                "url": "https://api.github.com/repos/FriendsOfSymfony/FOSHttpCache/zipball/e528b0fb046d3f329b10951201a5b0cab60e96e1",
+                "reference": "e528b0fb046d3f329b10951201a5b0cab60e96e1",
                 "shasum": ""
             },
             "require": {
@@ -1901,7 +2172,7 @@
                 "purge",
                 "varnish"
             ],
-            "time": "2017-08-18T11:35:28+00:00"
+            "time": "2017-10-09T11:34:53+00:00"
         },
         {
             "name": "friendsofsymfony/rest-bundle",
@@ -1993,16 +2264,16 @@
         },
         {
             "name": "gedmo/doctrine-extensions",
-            "version": "v2.4.30",
+            "version": "v2.4.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Atlantic18/DoctrineExtensions.git",
-                "reference": "5e2cc07beb0cd24345cbe02eb7afc3b23f9cd488"
+                "reference": "79cd1d49898a21ede9a5dfad41c021abd9a14339"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Atlantic18/DoctrineExtensions/zipball/5e2cc07beb0cd24345cbe02eb7afc3b23f9cd488",
-                "reference": "5e2cc07beb0cd24345cbe02eb7afc3b23f9cd488",
+                "url": "https://api.github.com/repos/Atlantic18/DoctrineExtensions/zipball/79cd1d49898a21ede9a5dfad41c021abd9a14339",
+                "reference": "79cd1d49898a21ede9a5dfad41c021abd9a14339",
                 "shasum": ""
             },
             "require": {
@@ -2067,7 +2338,7 @@
                 "tree",
                 "uploadable"
             ],
-            "time": "2017-07-02T09:46:37+00:00"
+            "time": "2017-10-12T06:26:21+00:00"
         },
         {
             "name": "goodby/csv",
@@ -2666,16 +2937,16 @@
         },
         {
             "name": "jms/serializer",
-            "version": "1.8.1",
+            "version": "1.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/schmittjoh/serializer.git",
-                "reference": "ce65798f722c836f16d5d7d2e3ca9d21e0fb4331"
+                "reference": "e708d6ef549044974b60a57fdcec2fa165436d57"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/serializer/zipball/ce65798f722c836f16d5d7d2e3ca9d21e0fb4331",
-                "reference": "ce65798f722c836f16d5d7d2e3ca9d21e0fb4331",
+                "url": "https://api.github.com/repos/schmittjoh/serializer/zipball/e708d6ef549044974b60a57fdcec2fa165436d57",
+                "reference": "e708d6ef549044974b60a57fdcec2fa165436d57",
                 "shasum": ""
             },
             "require": {
@@ -2714,7 +2985,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.8-dev"
+                    "dev-master": "1.9-dev"
                 }
             },
             "autoload": {
@@ -2745,7 +3016,7 @@
                 "serialization",
                 "xml"
             ],
-            "time": "2017-07-13T11:23:56+00:00"
+            "time": "2017-10-27T07:15:54+00:00"
         },
         {
             "name": "jms/serializer-bundle",
@@ -2821,16 +3092,16 @@
         },
         {
             "name": "layershifter/tld-database",
-            "version": "1.0.49",
+            "version": "1.0.51",
             "source": {
                 "type": "git",
                 "url": "https://github.com/layershifter/TLDDatabase.git",
-                "reference": "265ce85bf1ab490088defbcaf00c36c4661170ff"
+                "reference": "102bc740155d28471da7bfde66e504bf57e4ffb5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/layershifter/TLDDatabase/zipball/265ce85bf1ab490088defbcaf00c36c4661170ff",
-                "reference": "265ce85bf1ab490088defbcaf00c36c4661170ff",
+                "url": "https://api.github.com/repos/layershifter/TLDDatabase/zipball/102bc740155d28471da7bfde66e504bf57e4ffb5",
+                "reference": "102bc740155d28471da7bfde66e504bf57e4ffb5",
                 "shasum": ""
             },
             "require": {
@@ -2868,20 +3139,20 @@
                 "domain database",
                 "tld database"
             ],
-            "time": "2017-08-23T10:18:43+00:00"
+            "time": "2017-10-31T18:18:21+00:00"
         },
         {
             "name": "layershifter/tld-extract",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/layershifter/TLDExtract.git",
-                "reference": "a645ed9f3ee7a4bd769fbc1186dd2575ae6a4790"
+                "reference": "c27974a38e0b64248bbd859d71cec72464621070"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/layershifter/TLDExtract/zipball/a645ed9f3ee7a4bd769fbc1186dd2575ae6a4790",
-                "reference": "a645ed9f3ee7a4bd769fbc1186dd2575ae6a4790",
+                "url": "https://api.github.com/repos/layershifter/TLDExtract/zipball/c27974a38e0b64248bbd859d71cec72464621070",
+                "reference": "c27974a38e0b64248bbd859d71cec72464621070",
                 "shasum": ""
             },
             "require": {
@@ -2919,7 +3190,7 @@
                 "TLDExtract",
                 "domain parser"
             ],
-            "time": "2017-04-17T12:08:59+00:00"
+            "time": "2017-10-17T17:50:33+00:00"
         },
         {
             "name": "layershifter/tld-support",
@@ -3208,7 +3479,7 @@
         },
         {
             "name": "mtdowling/cron-expression",
-            "version": "v1.2.0",
+            "version": "v1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mtdowling/cron-expression.git",
@@ -3302,37 +3573,40 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.6.1",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "8e6e04167378abf1ddb4d3522d8755c5fd90d102"
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/8e6e04167378abf1ddb4d3522d8755c5fd90d102",
-                "reference": "8e6e04167378abf1ddb4d3522d8755c5fd90d102",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.0"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "doctrine/collections": "1.*",
-                "phpunit/phpunit": "~4.1"
+                "doctrine/collections": "^1.0",
+                "doctrine/common": "^2.6",
+                "phpunit/phpunit": "^4.1"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
                     "DeepCopy\\": "src/DeepCopy/"
-                }
+                },
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
             "description": "Create deep copies (clones) of your objects",
-            "homepage": "https://github.com/myclabs/DeepCopy",
             "keywords": [
                 "clone",
                 "copy",
@@ -3340,7 +3614,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-04-12T18:52:22+00:00"
+            "time": "2017-10-19T19:58:43+00:00"
         },
         {
             "name": "neutron/temporary-filesystem",
@@ -3826,16 +4100,16 @@
         },
         {
             "name": "phpdocumentor/reflection-common",
-            "version": "1.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c"
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
-                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
                 "shasum": ""
             },
             "require": {
@@ -3876,7 +4150,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2015-12-27T11:43:31+00:00"
+            "time": "2017-09-11T18:02:19+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -4022,22 +4296,22 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.7.0",
+            "version": "v1.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073"
+                "reference": "c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/93d39f1f7f9326d746203c7c056f300f7f126073",
-                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6",
+                "reference": "c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
                 "sebastian/comparator": "^1.1|^2.0",
                 "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
@@ -4048,7 +4322,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.6.x-dev"
+                    "dev-master": "1.7.x-dev"
                 }
             },
             "autoload": {
@@ -4081,7 +4355,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-03-02T20:05:34+00:00"
+            "time": "2017-09-04T11:05:03+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -4334,16 +4608,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.7.21",
+            "version": "5.7.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "3b91adfb64264ddec5a2dee9851f354aa66327db"
+                "reference": "78532d5269d984660080d8e0f4c99c5c2ea65ffe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3b91adfb64264ddec5a2dee9851f354aa66327db",
-                "reference": "3b91adfb64264ddec5a2dee9851f354aa66327db",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/78532d5269d984660080d8e0f4c99c5c2ea65ffe",
+                "reference": "78532d5269d984660080d8e0f4c99c5c2ea65ffe",
                 "shasum": ""
             },
             "require": {
@@ -4412,7 +4686,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-06-21T08:11:54+00:00"
+            "time": "2017-10-15T06:13:55+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -4475,16 +4749,16 @@
         },
         {
             "name": "piwik/device-detector",
-            "version": "3.8.1",
+            "version": "3.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/piwik/device-detector.git",
-                "reference": "91e17ecbd7ad6fe3085d5508aacdf858281087e5"
+                "reference": "88fe6919e63c71cbe831990215fa76a9f4d797b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/piwik/device-detector/zipball/91e17ecbd7ad6fe3085d5508aacdf858281087e5",
-                "reference": "91e17ecbd7ad6fe3085d5508aacdf858281087e5",
+                "url": "https://api.github.com/repos/piwik/device-detector/zipball/88fe6919e63c71cbe831990215fa76a9f4d797b5",
+                "reference": "88fe6919e63c71cbe831990215fa76a9f4d797b5",
                 "shasum": ""
             },
             "require": {
@@ -4493,7 +4767,10 @@
             },
             "require-dev": {
                 "fabpot/php-cs-fixer": "~1.7",
-                "phpunit/phpunit": "4.1.*"
+                "matthiasmullie/scrapbook": "@stable",
+                "phpunit/phpunit": "4.1.*",
+                "psr/cache": "^1.0",
+                "psr/simple-cache": "^1.0"
             },
             "suggest": {
                 "doctrine/cache": "Can directly be used for caching purpose"
@@ -4522,102 +4799,7 @@
                 "parser",
                 "useragent"
             ],
-            "time": "2017-07-25T21:21:36+00:00"
-        },
-        {
-            "name": "psr/cache",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/cache.git",
-                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
-                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Cache\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for caching libraries",
-            "keywords": [
-                "cache",
-                "psr",
-                "psr-6"
-            ],
-            "time": "2016-08-06T20:24:11+00:00"
-        },
-        {
-            "name": "psr/container",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/container.git",
-                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
-                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Container\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common Container Interface (PHP FIG PSR-11)",
-            "homepage": "https://github.com/php-fig/container",
-            "keywords": [
-                "PSR-11",
-                "container",
-                "container-interface",
-                "container-interop",
-                "psr"
-            ],
-            "time": "2017-02-14T16:28:37+00:00"
+            "time": "2017-10-30T17:47:32+00:00"
         },
         {
             "name": "psr/http-message",
@@ -4668,103 +4850,6 @@
                 "response"
             ],
             "time": "2016-08-06T14:39:51+00:00"
-        },
-        {
-            "name": "psr/link",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/link.git",
-                "reference": "eea8e8662d5cd3ae4517c9b864493f59fca95562"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/link/zipball/eea8e8662d5cd3ae4517c9b864493f59fca95562",
-                "reference": "eea8e8662d5cd3ae4517c9b864493f59fca95562",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Link\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interfaces for HTTP links",
-            "keywords": [
-                "http",
-                "http-link",
-                "link",
-                "psr",
-                "psr-13",
-                "rest"
-            ],
-            "time": "2016-10-28T16:06:13+00:00"
-        },
-        {
-            "name": "psr/simple-cache",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/simple-cache.git",
-                "reference": "753fa598e8f3b9966c886fe13f370baa45ef0e24"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/753fa598e8f3b9966c886fe13f370baa45ef0e24",
-                "reference": "753fa598e8f3b9966c886fe13f370baa45ef0e24",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\SimpleCache\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interfaces for simple caching",
-            "keywords": [
-                "cache",
-                "caching",
-                "psr",
-                "psr-16",
-                "simple-cache"
-            ],
-            "time": "2017-01-02T13:31:39+00:00"
         },
         {
             "name": "pulse00/ffmpeg-bundle",
@@ -4822,16 +4907,16 @@
         },
         {
             "name": "ramsey/uuid",
-            "version": "3.7.0",
+            "version": "3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/uuid.git",
-                "reference": "0ef23d1b10cf1bc576e9d865a7e9c47982c5715e"
+                "reference": "45cffe822057a09e05f7bd09ec5fb88eeecd2334"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/0ef23d1b10cf1bc576e9d865a7e9c47982c5715e",
-                "reference": "0ef23d1b10cf1bc576e9d865a7e9c47982c5715e",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/45cffe822057a09e05f7bd09ec5fb88eeecd2334",
+                "reference": "45cffe822057a09e05f7bd09ec5fb88eeecd2334",
                 "shasum": ""
             },
             "require": {
@@ -4900,7 +4985,7 @@
                 "identifier",
                 "uuid"
             ],
-            "time": "2017-08-04T13:39:04+00:00"
+            "time": "2017-09-22T20:46:04+00:00"
         },
         {
             "name": "react/event-loop",
@@ -5814,16 +5899,16 @@
         },
         {
             "name": "sulu/sulu",
-            "version": "1.6.3",
+            "version": "1.6.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sulu/sulu.git",
-                "reference": "f59279cb837e8758f6093b2d08379c97fd02face"
+                "reference": "c36b4753a6ee04c832149113382a690f009fe862"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sulu/sulu/zipball/f59279cb837e8758f6093b2d08379c97fd02face",
-                "reference": "f59279cb837e8758f6093b2d08379c97fd02face",
+                "url": "https://api.github.com/repos/sulu/sulu/zipball/c36b4753a6ee04c832149113382a690f009fe862",
+                "reference": "c36b4753a6ee04c832149113382a690f009fe862",
                 "shasum": ""
             },
             "require": {
@@ -5931,7 +6016,7 @@
                 "core",
                 "sulu"
             ],
-            "time": "2017-08-17T11:13:05+00:00"
+            "time": "2017-10-12T11:52:11+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",
@@ -5989,16 +6074,16 @@
         },
         {
             "name": "symfony-cmf/routing",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony-cmf/routing.git",
-                "reference": "97def24f83063ab3c96872c5e4b83ccc19e8f240"
+                "reference": "145993be08b2f0362e43e138548acdf4334d5209"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony-cmf/routing/zipball/97def24f83063ab3c96872c5e4b83ccc19e8f240",
-                "reference": "97def24f83063ab3c96872c5e4b83ccc19e8f240",
+                "url": "https://api.github.com/repos/symfony-cmf/routing/zipball/145993be08b2f0362e43e138548acdf4334d5209",
+                "reference": "145993be08b2f0362e43e138548acdf4334d5209",
                 "shasum": ""
             },
             "require": {
@@ -6045,26 +6130,27 @@
                 "database",
                 "routing"
             ],
-            "time": "2017-05-09T08:14:24+00:00"
+            "time": "2017-09-27T06:23:01+00:00"
         },
         {
             "name": "symfony-cmf/routing-bundle",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony-cmf/routing-bundle.git",
-                "reference": "201ca313b599bda335cea350256045da05972412"
+                "reference": "3c6331fa664991065aa29423da2fcb940d42f578"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony-cmf/routing-bundle/zipball/201ca313b599bda335cea350256045da05972412",
-                "reference": "201ca313b599bda335cea350256045da05972412",
+                "url": "https://api.github.com/repos/symfony-cmf/routing-bundle/zipball/3c6331fa664991065aa29423da2fcb940d42f578",
+                "reference": "3c6331fa664991065aa29423da2fcb940d42f578",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.6|^7.0",
                 "symfony-cmf/routing": "^2.0",
-                "symfony/framework-bundle": "^2.8|^3.0"
+                "symfony/framework-bundle": "^2.8|^3.0",
+                "symfony/twig-bundle": "^2.8|^3.0"
             },
             "conflict": {
                 "doctrine/phpcr-odm": "<1.4"
@@ -6110,7 +6196,7 @@
                 "database",
                 "routing"
             ],
-            "time": "2017-02-24T18:36:52+00:00"
+            "time": "2017-09-26T21:30:30+00:00"
         },
         {
             "name": "symfony-cmf/slugifier-api",
@@ -6161,16 +6247,16 @@
         },
         {
             "name": "symfony/swiftmailer-bundle",
-            "version": "v2.6.3",
+            "version": "v2.6.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/swiftmailer-bundle.git",
-                "reference": "11555c338f3c367b0a1bd2f024a53aa813f4ce00"
+                "reference": "c4808f5169efc05567be983909d00f00521c53ec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/swiftmailer-bundle/zipball/11555c338f3c367b0a1bd2f024a53aa813f4ce00",
-                "reference": "11555c338f3c367b0a1bd2f024a53aa813f4ce00",
+                "url": "https://api.github.com/repos/symfony/swiftmailer-bundle/zipball/c4808f5169efc05567be983909d00f00521c53ec",
+                "reference": "c4808f5169efc05567be983909d00f00521c53ec",
                 "shasum": ""
             },
             "require": {
@@ -6216,7 +6302,7 @@
             ],
             "description": "Symfony SwiftmailerBundle",
             "homepage": "http://symfony.com",
-            "time": "2017-07-22T07:18:13+00:00"
+            "time": "2017-10-19T01:06:41+00:00"
         },
         {
             "name": "true/punycode",
@@ -6635,5 +6721,8 @@
     "platform": {
         "php": "^5.6 || ^7.0"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "5.6.32"
+    }
 }

--- a/src/DependencyInjection/ConnectHollandLdapExtension.php
+++ b/src/DependencyInjection/ConnectHollandLdapExtension.php
@@ -6,6 +6,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\Ldap\Entry;
 
 /**
  * Loads and manages the bundle configuration.
@@ -21,5 +22,12 @@ class ConnectHollandLdapExtension extends Extension
     {
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
+
+        $additionalServicesFile = 'services_ldap.xml';
+        if (class_exists(Entry::class)) {
+            $additionalServicesFile = 'services_ldap_entry.xml';
+        }
+
+        $loader->load($additionalServicesFile);
     }
 }

--- a/src/DependencyInjection/ObjectFactory.php
+++ b/src/DependencyInjection/ObjectFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace ConnectHolland\LdapBundle\DependencyInjection;
+
+use Symfony\Component\Ldap\Ldap;
+
+/**
+ * Creates objects for the service container.
+ *
+ * @author Niels Nijens <niels@connectholland.nl>
+ */
+class ObjectFactory
+{
+    /**
+     * Creates a new Ldap instance.
+     *
+     * @param array $configuration
+     *
+     * @return Ldap
+     */
+    public static function createLdap(array $configuration)
+    {
+        return Ldap::create('ext_ldap', $configuration);
+    }
+}

--- a/src/DependencyInjection/Security/UserProvider/LdapFactory.php
+++ b/src/DependencyInjection/Security/UserProvider/LdapFactory.php
@@ -7,6 +7,7 @@ use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Ldap\Entry;
 
 /**
  * LdapFactory creates services for the LDAP user provider.
@@ -156,6 +157,13 @@ class LdapFactory implements UserProviderFactoryInterface
      */
     private function createLdapClientDefinition(ContainerBuilder $container, $id, array $configuration)
     {
+        if (class_exists(Entry::class)) {
+            $container->setDefinition($id.'.client', new DefinitionDecorator('connect_holland_ldap.ldap'))
+                ->replaceArgument(0, $configuration);
+
+            return;
+        }
+
         $encryptionSsl = isset($configuration['encryption']) && $configuration['encryption'] === 'ssl';
         $encryptionTls = isset($configuration['encryption']) && $configuration['encryption'] === 'tls';
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -5,33 +5,11 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="connect_holland_ldap.security.user.provider.ldap.class">ConnectHolland\LdapBundle\Security\User\LdapUserProvider</parameter>
-        <parameter key="connect_holland_ldap.ldap.client.class">Symfony\Component\Ldap\LdapClient</parameter>
         <parameter key="connect_holland_ldap.security.user.factory.doctrine.class">ConnectHolland\LdapBundle\Security\User\Factory\DoctrineUserFactory</parameter>
         <parameter key="connect_holland_ldap.security.user.factory.sulu.class">ConnectHolland\LdapBundle\Security\User\Factory\SuluUserFactory</parameter>
     </parameters>
 
     <services>
-        <service id="connect_holland_ldap.security.user.provider.ldap" class="%connect_holland_ldap.security.user.provider.ldap.class%" abstract="true" public="false">
-            <argument/> <!-- connect_holland_ldap.security.user.factory -->
-            <argument/> <!-- connect_holland_ldap.ldap.client -->
-            <argument/> <!-- base_dn -->
-            <argument/> <!-- search_dn -->
-            <argument/> <!-- search_password -->
-            <argument/> <!-- default_roles -->
-            <argument/> <!-- uid_key -->
-            <argument/> <!-- filter -->
-        </service>
-
-        <service id="connect_holland_ldap.ldap.client" class="%connect_holland_ldap.ldap.client.class%" abstract="true" public="false">
-            <argument/> <!-- host -->
-            <argument/> <!-- port -->
-            <argument/> <!-- options.protocol_version -->
-            <argument/> <!-- encryption ssl -->
-            <argument/> <!-- encryption tls -->
-            <argument/> <!-- options.referrals -->
-        </service>
-
         <service id="connect_holland_ldap.security.user.factory.doctrine" class="%connect_holland_ldap.security.user.factory.doctrine.class%" abstract="true" public="false">
             <argument type="service" id="doctrine"/>
             <argument/> <!-- user_class -->

--- a/src/Resources/config/services_ldap.xml
+++ b/src/Resources/config/services_ldap.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="connect_holland_ldap.security.user.provider.ldap.class">ConnectHolland\LdapBundle\Security\User\LdapUserProvider</parameter>
+        <parameter key="connect_holland_ldap.ldap.client.class">Symfony\Component\Ldap\LdapClient</parameter>
+    </parameters>
+
+    <services>
+        <service id="connect_holland_ldap.security.user.provider.ldap" class="%connect_holland_ldap.security.user.provider.ldap.class%" abstract="true" public="false">
+            <argument/> <!-- connect_holland_ldap.security.user.factory -->
+            <argument/> <!-- connect_holland_ldap.ldap.client -->
+            <argument/> <!-- base_dn -->
+            <argument/> <!-- search_dn -->
+            <argument/> <!-- search_password -->
+            <argument/> <!-- default_roles -->
+            <argument/> <!-- uid_key -->
+            <argument/> <!-- filter -->
+        </service>
+
+        <service id="connect_holland_ldap.ldap.client" class="%connect_holland_ldap.ldap.client.class%" abstract="true" public="false">
+            <argument/> <!-- host -->
+            <argument/> <!-- port -->
+            <argument/> <!-- options.protocol_version -->
+            <argument/> <!-- encryption ssl -->
+            <argument/> <!-- encryption tls -->
+            <argument/> <!-- options.referrals -->
+        </service>
+    </services>
+</container>

--- a/src/Resources/config/services_ldap_entry.xml
+++ b/src/Resources/config/services_ldap_entry.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="connect_holland_ldap.object_factory.class">ConnectHolland\LdapBundle\DependencyInjection\ObjectFactory</parameter>
+        <parameter key="connect_holland_ldap.security.user.provider.ldap.class">ConnectHolland\LdapBundle\Security\User\LdapEntryUserProvider</parameter>
+        <parameter key="connect_holland_ldap.ldap.class">Symfony\Component\Ldap\Ldap</parameter>
+    </parameters>
+
+    <services>
+        <service id="connect_holland_ldap.security.user.provider.ldap" class="%connect_holland_ldap.security.user.provider.ldap.class%" abstract="true" public="false">
+            <argument/> <!-- connect_holland_ldap.security.user.factory -->
+            <argument/> <!-- connect_holland_ldap.ldap.client -->
+            <argument/> <!-- base_dn -->
+            <argument/> <!-- search_dn -->
+            <argument/> <!-- search_password -->
+            <argument/> <!-- default_roles -->
+            <argument/> <!-- uid_key -->
+            <argument/> <!-- filter -->
+        </service>
+
+        <service id="connect_holland_ldap.ldap" class="%connect_holland_ldap.ldap.class%" abstract="true" public="false">
+            <factory class="%connect_holland_ldap.object_factory.class%" method="createLdap"/>
+
+            <argument/> <!-- configuration -->
+        </service>
+    </services>
+</container>

--- a/src/Security/User/Factory/AbstractUserFactory.php
+++ b/src/Security/User/Factory/AbstractUserFactory.php
@@ -42,7 +42,7 @@ abstract class AbstractUserFactory implements UserFactoryInterface
     protected function updateUserWithLdapProperties(UserInterface $user, array $ldapUserProperties)
     {
         foreach ($this->userPropertyMap as $ldapKey => $propertyPath) {
-            if (isset($ldapUserProperties[$ldapKey]) === false || $ldapUserProperties[$ldapKey]['count'] === 0) {
+            if (isset($ldapUserProperties[$ldapKey][0]) === false) {
                 continue;
             }
 

--- a/src/Security/User/LdapEntryUserProvider.php
+++ b/src/Security/User/LdapEntryUserProvider.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace ConnectHolland\LdapBundle\Security\User;
+
+use ConnectHolland\LdapBundle\Security\User\Factory\UserFactoryInterface;
+use Symfony\Component\Ldap\Entry;
+use Symfony\Component\Ldap\LdapInterface;
+use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
+use Symfony\Component\Security\Core\User\LdapUserProvider as BaseLdapUserProvider;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * LdapEntryUserProvider.
+ *
+ * @author Niels Nijens <niels@connectholland.nl>
+ */
+class LdapEntryUserProvider extends BaseLdapUserProvider
+{
+    /**
+     * @var UserFactoryInterface
+     */
+    private $userFactory;
+
+    /**
+     * @var array
+     */
+    private $defaultRoles;
+
+    /**
+     * Constructs a new LdapUserProvider instance.
+     *
+     * @param UserFactoryInterface $userFactory
+     * @param LdapInterface        $ldap
+     * @param string               $baseDn
+     * @param string               $searchDn
+     * @param string               $searchPassword
+     * @param array                $defaultRoles
+     * @param string               $uidKey
+     * @param string               $filter
+     */
+    public function __construct(UserFactoryInterface $userFactory, LdapInterface $ldap, $baseDn, $searchDn = null, $searchPassword = null, array $defaultRoles = array(), $uidKey = 'sAMAccountName', $filter = '({uid_key}={username})')
+    {
+        $this->userFactory = $userFactory;
+        $this->defaultRoles = $defaultRoles;
+
+        parent::__construct($ldap, $baseDn, $searchDn, $searchPassword, $defaultRoles, $uidKey, $filter);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function refreshUser(UserInterface $user)
+    {
+        $userClass = $this->userFactory->getUserClass();
+        if ($user instanceof $userClass === false) {
+            throw new UnsupportedUserException(
+                sprintf('Instances of "%s" are not supported.', get_class($user))
+            );
+        }
+
+        return $this->userFactory->getOrCreate($user->getUsername(), array(), array());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsClass($class)
+    {
+        return $class === $this->userFactory->getUserClass();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function loadUser($username, Entry $entry)
+    {
+        return $this->userFactory->getOrCreate($username, $entry->getAttributes(), $this->defaultRoles);
+    }
+}

--- a/tests/DependencyInjection/ConnectHollandLdapExtensionTest.php
+++ b/tests/DependencyInjection/ConnectHollandLdapExtensionTest.php
@@ -4,6 +4,7 @@ namespace ConnectHolland\LdapBundle\Test\DependencyInjection;
 
 use ConnectHolland\LdapBundle\DependencyInjection\ConnectHollandLdapExtension;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Symfony\Component\Ldap\Entry;
 
 /**
  * ConnectHollandLdapExtensionTest.
@@ -17,6 +18,10 @@ class ConnectHollandLdapExtensionTest extends AbstractExtensionTestCase
      */
     public function testLoad()
     {
+        if (class_exists(Entry::class)) {
+            $this->markTestSkipped('This test is only functional with Symfony 2.8 - 3.0');
+        }
+
         $this->load();
 
         $this->assertContainerBuilderHasService('connect_holland_ldap.security.user.provider.ldap', 'ConnectHolland\\LdapBundle\\Security\\User\\LdapUserProvider');

--- a/tests/DependencyInjection/ConnectHollandLdapExtensionTest.php
+++ b/tests/DependencyInjection/ConnectHollandLdapExtensionTest.php
@@ -31,6 +31,23 @@ class ConnectHollandLdapExtensionTest extends AbstractExtensionTestCase
     }
 
     /**
+     * Tests if the ConnectHollandLdapExtension loads the abstract services.
+     */
+    public function testLoadLdapEntry()
+    {
+        if (class_exists(Entry::class) === false) {
+            $this->markTestSkipped('This test is only functional with Symfony 3.1+');
+        }
+
+        $this->load();
+
+        $this->assertContainerBuilderHasService('connect_holland_ldap.security.user.provider.ldap', 'ConnectHolland\\LdapBundle\\Security\\User\\LdapEntryUserProvider');
+        $this->assertContainerBuilderHasService('connect_holland_ldap.ldap', 'Symfony\\Component\\Ldap\\Ldap');
+        $this->assertContainerBuilderHasService('connect_holland_ldap.security.user.factory.doctrine', 'ConnectHolland\\LdapBundle\\Security\\User\\Factory\\DoctrineUserFactory');
+        $this->assertContainerBuilderHasService('connect_holland_ldap.security.user.factory.sulu', 'ConnectHolland\\LdapBundle\\Security\\User\\Factory\\SuluUserFactory');
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function getContainerExtensions()

--- a/tests/DependencyInjection/ObjectFactoryTest.php
+++ b/tests/DependencyInjection/ObjectFactoryTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace ConnectHolland\LdapBundle\Test\DependencyInjection;
+
+use ConnectHolland\LdapBundle\DependencyInjection\ObjectFactory;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Ldap\Entry;
+use Symfony\Component\Ldap\Ldap;
+
+/**
+ * ObjectFactoryTest.
+ *
+ * @author Niels Nijens <niels@connectholland.nl>
+ */
+class ObjectFactoryTest extends TestCase
+{
+    /**
+     * The ObjectFactory being tested.
+     *
+     * @var ObjectFactory
+     */
+    private $objectFactory;
+
+    /**
+     * Creates a new ObjectFactory instance for testing.
+     */
+    public function setUp()
+    {
+        if (class_exists(Entry::class) === false) {
+            $this->markTestSkipped('This test is only functional with Symfony 3.1+');
+        }
+
+        $this->objectFactory = new ObjectFactory();
+    }
+
+    /**
+     * Tests if ObjectFactory::createLdap creates a new Ldap instance.
+     */
+    public function testCreateLdap()
+    {
+        $ldap = $this->objectFactory->createLdap(array());
+
+        $this->assertInstanceOf(Ldap::class, $ldap);
+    }
+}

--- a/tests/DependencyInjection/Security/UserProvider/LdapFactoryTest.php
+++ b/tests/DependencyInjection/Security/UserProvider/LdapFactoryTest.php
@@ -7,6 +7,7 @@ use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractContainerBuilderTestCase;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Ldap\Entry;
 
 /**
  * LdapFactoryTest.
@@ -84,10 +85,14 @@ class LdapFactoryTest extends AbstractContainerBuilderTestCase
     }
 
     /**
-     * Tests if LdapFactory::create creates the service definitions.
+     * Tests if LdapFactory::create creates the service definitions with Symfony 2.8 - 3.0.
      */
     public function testCreate()
     {
+        if (class_exists(Entry::class)) {
+            $this->markTestSkipped('This test is only functional with Symfony 2.8 - 3.0');
+        }
+
         $this->ldapFactory->create(
             $this->container,
             'security.user.provider.concrete.my_ldap',
@@ -130,6 +135,10 @@ class LdapFactoryTest extends AbstractContainerBuilderTestCase
      */
     public function testCreateWithCustomUserFactory()
     {
+        if (class_exists(Entry::class)) {
+            $this->markTestSkipped('This test is only functional with Symfony 2.8 - 3.0');
+        }
+
         $this->ldapFactory->create(
             $this->container,
             'security.user.provider.concrete.my_ldap',

--- a/tests/Security/User/LdapEntryUserProviderTest.php
+++ b/tests/Security/User/LdapEntryUserProviderTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace ConnectHolland\LdapBundle\Test\Security\User;
+
+use ConnectHolland\LdapBundle\Security\User\Factory\UserFactoryInterface;
+use ConnectHolland\LdapBundle\Security\User\LdapEntryUserProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Ldap\Adapter\QueryInterface;
+use Symfony\Component\Ldap\Entry;
+use Symfony\Component\Ldap\LdapInterface;
+use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * LdapEntryUserProviderTest.
+ *
+ * @author Niels Nijens <niels@connectholland.nl>
+ */
+class LdapEntryUserProviderTest extends TestCase
+{
+    /**
+     * @var UserFactoryInterface
+     */
+    private $userFactoryMock;
+
+    /**
+     * @var LdapInterface
+     */
+    private $ldapMock;
+
+    /**
+     * The LdapEntryUserProvider being tested.
+     *
+     * @var LdapEntryUserProvider
+     */
+    private $ldapUserProvider;
+
+    /**
+     * Creates a LdapEntryUserProvider instance for testing.
+     */
+    public function setUp()
+    {
+        if (class_exists(Entry::class) === false) {
+            $this->markTestSkipped('The LdapEntryUserProvider is only functional with Symfony 3.1+');
+        }
+
+        $this->userFactoryMock = $this->getMockBuilder(UserFactoryInterface::class)
+            ->getMock();
+
+        $this->ldapMock = $this->getMockBuilder(LdapInterface::class)
+            ->getMock();
+
+        $this->ldapUserProvider = new LdapEntryUserProvider($this->userFactoryMock, $this->ldapMock, 'ou=users,dc=example,dc=com', null, null, array('ROLE_ADMIN'), 'uid');
+    }
+
+    /**
+     * Tests if constructing a new LdapEntryUserProvider instance sets the instance properties.
+     */
+    public function testConstruct()
+    {
+        $this->assertAttributeSame($this->userFactoryMock, 'userFactory', $this->ldapUserProvider);
+        $this->assertAttributeSame(array('ROLE_ADMIN'), 'defaultRoles', $this->ldapUserProvider);
+    }
+
+    /**
+     * Tests if LdapEntryUserProvider::supportsClass uses the user class from the user factory to validate if the LdapUserProvider supports the class.
+     */
+    public function testSupportsClass()
+    {
+        $this->userFactoryMock->expects($this->once())
+            ->method('getUserClass')
+            ->willReturn('User');
+
+        $this->assertTrue($this->ldapUserProvider->supportsClass('User'));
+    }
+
+    /**
+     * Tests if LdapEntryUserProvider::loadUser calls the getOrCreate method on the user factory and returns a user instance.
+     */
+    public function testLoadUser()
+    {
+        $entry = new Entry('uid=john,ou=users,dc=example,dc=com', array('uid' => array('john')));
+
+        $queryMock = $this->getMockBuilder(QueryInterface::class)
+            ->getMock();
+        $queryMock->expects($this->once())
+            ->method('execute')
+            ->willReturn(array($entry));
+
+        $this->ldapMock->expects($this->once())
+            ->method('query')
+            ->willReturn($queryMock);
+
+        $userMock = $this->getMockBuilder(UserInterface::class)
+            ->getMock();
+
+        $this->userFactoryMock->expects($this->once())
+            ->method('getOrCreate')
+            ->with($this->equalTo('john'), $this->equalTo(array('uid' => array('john'))))
+            ->willReturn($userMock);
+
+        $this->assertInstanceOf(UserInterface::class, $this->ldapUserProvider->loadUserByUsername('john'));
+    }
+
+    /**
+     * Tests if LdapEntryUserProvider::refreshUser calls the getOrCreate method on the user factory to refresh the user instance.
+     */
+    public function testRefreshUser()
+    {
+        $userMock = $this->getMockBuilder(UserInterface::class)
+            ->getMock();
+        $userMock->expects($this->once())
+            ->method('getUsername')
+            ->willReturn('john');
+
+        $this->userFactoryMock->expects($this->once())
+            ->method('getUserClass')
+            ->willReturn(UserInterface::class);
+        $this->userFactoryMock->expects($this->once())
+            ->method('getOrCreate')
+            ->with($this->equalTo('john'), $this->equalTo(array()))
+            ->willReturn($userMock);
+
+        $this->assertInstanceOf(UserInterface::class, $this->ldapUserProvider->refreshUser($userMock));
+    }
+
+    /**
+     * Tests if LdapEntryUserProvider::refreshUser throws an UnsupportedUserException when the user factory does not support the user instance.
+     */
+    public function testRefreshUserThrowsUnsupportedUserException()
+    {
+        $userMock = $this->getMockBuilder(UserInterface::class)
+            ->setMockClassName('NoUser')
+            ->getMock();
+        $userMock->expects($this->never())
+            ->method('getUsername');
+
+        $this->userFactoryMock->expects($this->once())
+            ->method('getUserClass')
+            ->willReturn('User');
+        $this->userFactoryMock->expects($this->never())
+            ->method('getOrCreate');
+
+        $this->expectException(UnsupportedUserException::class);
+        $this->expectExceptionMessage('Instances of "NoUser" are not supported.');
+
+        $this->ldapUserProvider->refreshUser($userMock);
+    }
+}

--- a/tests/Security/User/LdapUserProviderTest.php
+++ b/tests/Security/User/LdapUserProviderTest.php
@@ -5,6 +5,7 @@ namespace ConnectHolland\LdapBundle\Test\Security\User;
 use ConnectHolland\LdapBundle\Security\User\Factory\UserFactoryInterface;
 use ConnectHolland\LdapBundle\Security\User\LdapUserProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Ldap\Entry;
 use Symfony\Component\Ldap\LdapClientInterface;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -38,6 +39,10 @@ class LdapUserProviderTest extends TestCase
      */
     public function setUp()
     {
+        if (class_exists(Entry::class)) {
+            $this->markTestSkipped('The LdapUserProvider is only functional with Symfony 2.8 - 3.0');
+        }
+
         $this->userFactoryMock = $this->getMockBuilder(UserFactoryInterface::class)
             ->getMock();
 


### PR DESCRIPTION
This PR adds (cross-)compatibility for the updated Symfony 3.1 LDAP component.